### PR TITLE
prevent reentracy during minting from messing up the data integrity

### DIFF
--- a/contracts/ERC721Psi.sol
+++ b/contracts/ERC721Psi.sol
@@ -349,6 +349,9 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerab
 
         _owners[tokenIdBatchHead] = to;
         _batchHead.set(tokenIdBatchHead);
+
+        // Reentrancy Protection
+        require(tokenIdBatchHead == _minted);
         _minted += quantity;
 
         _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);

--- a/contracts/ERC721Psi.sol
+++ b/contracts/ERC721Psi.sol
@@ -273,7 +273,7 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerab
     ) internal virtual {
         _transfer(from, to, tokenId);
         require(
-            _checkOnERC721Received(from, to, tokenId, _data),
+            _checkOnERC721Received(from, to, tokenId, 1,_data),
             "ERC721Psi: transfer to non ERC721Receiver implementer"
         );
     }
@@ -332,27 +332,32 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerab
         uint256 quantity,
         bytes memory _data
     ) internal virtual {
+        uint256 startTokenId = _minted;
+        _mint(to, quantity);
+        require(
+            _checkOnERC721Received(address(0), to, startTokenId, quantity, _data),
+            "ERC721Psi: transfer to non ERC721Receiver implementer"
+        );
+    }
+
+
+    function _mint(
+        address to,
+        uint256 quantity
+    ) internal virtual {
         uint256 tokenIdBatchHead = _minted;
         
         require(quantity > 0, "ERC721Psi: quantity must be greater 0");
         require(to != address(0), "ERC721Psi: mint to the zero address");
         
         _beforeTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
-        for(uint256 i=0;i < quantity; i++){
-            uint256 tokenId = tokenIdBatchHead + i;
+        _minted += quantity;
+        for(uint256 tokenId=tokenIdBatchHead;tokenId < tokenIdBatchHead + quantity; tokenId++){
             emit Transfer(address(0), to, tokenId);
-            require(
-                _checkOnERC721Received(address(0), to, tokenId, _data),
-                "ERC721Psi: transfer to non ERC721Receiver implementer"
-            );
-        }
-
+        } 
+        
         _owners[tokenIdBatchHead] = to;
         _batchHead.set(tokenIdBatchHead);
-
-        // Reentrancy Protection
-        require(tokenIdBatchHead == _minted);
-        _minted += quantity;
 
         _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
     }
@@ -422,37 +427,34 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerab
      *
      * @param from address representing the previous owner of the given token ID
      * @param to target address that will receive the tokens
-     * @param tokenId uint256 ID of the token to be transferred
+     * @param startTokenId uint256 the first ID of the tokens to be transferred
+     * @param quantity uint256 amount of the tokens to be transfered.
      * @param _data bytes optional data to send along with the call
-     * @return bool whether the call correctly returned the expected magic value
+     * @return r bool whether the call correctly returned the expected magic value
      */
     function _checkOnERC721Received(
         address from,
         address to,
-        uint256 tokenId,
+        uint256 startTokenId,
+        uint256 quantity,
         bytes memory _data
-    ) private returns (bool) {
+    ) private returns (bool r) {
         if (to.isContract()) {
-            try
-                IERC721Receiver(to).onERC721Received(
-                    _msgSender(),
-                    from,
-                    tokenId,
-                    _data
-                )
-            returns (bytes4 retval) {
-                return retval == IERC721Receiver.onERC721Received.selector;
-            } catch (bytes memory reason) {
-                if (reason.length == 0) {
-                    revert(
-                        "ERC721Psi: transfer to non ERC721Receiver implementer"
-                    );
-                } else {
-                    assembly {
-                        revert(add(32, reason), mload(reason))
+            r = true;
+            for(uint256 tokenId = startTokenId; tokenId < startTokenId + quantity; tokenId++){
+                try IERC721Receiver(to).onERC721Received(_msgSender(), from, tokenId, _data) returns (bytes4 retval) {
+                    r = r && retval == IERC721Receiver.onERC721Received.selector;
+                } catch (bytes memory reason) {
+                    if (reason.length == 0) {
+                        revert("ERC721Psi: transfer to non ERC721Receiver implementer");
+                    } else {
+                        assembly {
+                            revert(add(32, reason), mload(reason))
+                        }
                     }
                 }
             }
+            return r;
         } else {
             return true;
         }
@@ -489,8 +491,7 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerab
      */
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256 tokenId) {
         uint count;
-        uint n = _minted;
-        for(uint i; i < n; i++){
+        for(uint i; i < _minted; i++){
             if(_exists(i) && owner == ownerOf(i)){
                 if(count == index) return i;
                 else count++;

--- a/contracts/ERC721Psi.sol
+++ b/contracts/ERC721Psi.sol
@@ -352,14 +352,14 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerab
         
         _beforeTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
         _minted += quantity;
+        _owners[tokenIdBatchHead] = to;
+        _batchHead.set(tokenIdBatchHead);
+        _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
+        
+        // Emit events
         for(uint256 tokenId=tokenIdBatchHead;tokenId < tokenIdBatchHead + quantity; tokenId++){
             emit Transfer(address(0), to, tokenId);
         } 
-        
-        _owners[tokenIdBatchHead] = to;
-        _batchHead.set(tokenIdBatchHead);
-
-        _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
     }
 
 

--- a/contracts/ERC721PsiUpgradeable.sol
+++ b/contracts/ERC721PsiUpgradeable.sol
@@ -360,14 +360,14 @@ contract ERC721PsiUpgradeable is Initializable, ContextUpgradeable,
         
         _beforeTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
         _minted += quantity;
+        _owners[tokenIdBatchHead] = to;
+        _batchHead.set(tokenIdBatchHead);
+        _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
+        
+        // Emit events
         for(uint256 tokenId=tokenIdBatchHead;tokenId < tokenIdBatchHead + quantity; tokenId++){
             emit Transfer(address(0), to, tokenId);
         } 
-        
-        _owners[tokenIdBatchHead] = to;
-        _batchHead.set(tokenIdBatchHead);
-
-        _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);
     }
 
 

--- a/contracts/ERC721PsiUpgradeable.sol
+++ b/contracts/ERC721PsiUpgradeable.sol
@@ -356,6 +356,9 @@ contract ERC721PsiUpgradeable is Initializable, ContextUpgradeable,
 
         _owners[tokenIdBatchHead] = to;
         _batchHead.set(tokenIdBatchHead);
+
+        // Reentrancy Protection
+        require(tokenIdBatchHead == _minted);
         _minted += quantity;
 
         _afterTokenTransfers(address(0), to, tokenIdBatchHead, quantity);


### PR DESCRIPTION
Move the `_checkOnERC721Received` to the end of the `_safeMint` function to prevent reentrancy from messing up the data integrity. The reentrancy can only happened after the minting process is completed or before the process starts.

However, it is highly recommended to implement reentrancy guard in your mint function.