### PR TITLE
use queryable interface and change some internal interface to match E…

### DIFF
--- a/contracts/extension/ERC721PsiBatchMetaData.sol
+++ b/contracts/extension/ERC721PsiBatchMetaData.sol
@@ -26,8 +26,7 @@ abstract contract ERC721PsiBatchMetaData is ERC721Psi {
         uint256 quantity,
         bytes memory _data
     ) internal virtual override {
-        uint256 tokenIdBatchHead = _minted;
-        _metaDataBatchHead.set(tokenIdBatchHead);
+        _metaDataBatchHead.set(_nextTokenId());
         super._safeMint(to, quantity, _data);
     }
 

--- a/contracts/extension/ERC721PsiBatchMetaDataUpgradeable.sol
+++ b/contracts/extension/ERC721PsiBatchMetaDataUpgradeable.sol
@@ -26,8 +26,7 @@ abstract contract ERC721PsiBatchMetaDataUpgradeable is ERC721PsiUpgradeable {
         uint256 quantity,
         bytes memory _data
     ) internal virtual override {
-        uint256 tokenIdBatchHead = _minted;
-        _metaDataBatchHead.set(tokenIdBatchHead);
+        _metaDataBatchHead.set(_nextTokenId());
         super._safeMint(to, quantity, _data);
     }
 

--- a/contracts/extension/ERC721PsiBurnable.sol
+++ b/contracts/extension/ERC721PsiBurnable.sol
@@ -58,16 +58,17 @@ abstract contract ERC721PsiBurnable is ERC721Psi {
      * @dev See {IERC721Enumerable-totalSupply}.
      */
     function totalSupply() public view virtual override returns (uint256) {
-        return _minted - _burned();
+        return _totalMinted() - _burned();
     }
 
     /**
      * @dev Returns number of token burned.
      */
     function _burned() internal view returns (uint256 burned){
-        uint256 totalBucket = (_minted >> 8) + 1;
+        uint256 startBucket = _startTokenId() >> 8;
+        uint256 lastBucket = (_nextTokenId() >> 8) + 1;
 
-        for(uint256 i=0; i < totalBucket; i++) {
+        for(uint256 i=startBucket; i < lastBucket; i++) {
             uint256 bucket = _burnedToken.getBucket(i);
             burned += _popcount(bucket);
         }

--- a/contracts/extension/ERC721PsiBurnableUpgradeable.sol
+++ b/contracts/extension/ERC721PsiBurnableUpgradeable.sol
@@ -58,16 +58,17 @@ abstract contract ERC721PsiBurnableUpgradeable is ERC721PsiUpgradeable {
      * @dev See {IERC721Enumerable-totalSupply}.
      */
     function totalSupply() public view virtual override returns (uint256) {
-        return _minted - _burned();
+        return _totalMinted() - _burned();
     }
 
     /**
      * @dev Returns number of token burned.
      */
     function _burned() internal view returns (uint256 burned){
-        uint256 totalBucket = (_minted >> 8) + 1;
+        uint256 startBucket = _startTokenId() >> 8;
+        uint256 lastBucket = (_nextTokenId() >> 8) + 1;
 
-        for(uint256 i=0; i < totalBucket; i++) {
+        for(uint256 i=startBucket; i < lastBucket; i++) {
             uint256 bucket = _burnedToken.getBucket(i);
             burned += _popcount(bucket);
         }

--- a/contracts/extension/ERC721PsiRandomSeed.sol
+++ b/contracts/extension/ERC721PsiRandomSeed.sol
@@ -60,7 +60,7 @@ abstract contract ERC721PsiRandomSeed is IERC721RandomSeed, ERC721PsiBatchMetaDa
         uint256 quantity,
         bytes memory _data
     ) internal virtual override {
-        uint256 tokenIdHead = _minted;
+        uint256 nextTokenId = _nextTokenId();
 
         uint256 requestId = COORDINATOR.requestRandomWords(
             _keyHash(),
@@ -71,9 +71,9 @@ abstract contract ERC721PsiRandomSeed is IERC721RandomSeed, ERC721PsiBatchMetaDa
         );
 
         emit RandomnessRequest(requestId);
-        requestIdToTokenId[requestId] = tokenIdHead;
+        requestIdToTokenId[requestId] = nextTokenId;
         super._safeMint(to, quantity, _data);
-        _processRandomnessRequest(requestId, tokenIdHead);
+        _processRandomnessRequest(requestId, nextTokenId);
     }
 
     /** 

--- a/contracts/extension/ERC721PsiRandomSeedReveal.sol
+++ b/contracts/extension/ERC721PsiRandomSeedReveal.sol
@@ -66,8 +66,8 @@ abstract contract ERC721PsiRandomSeedReveal is IERC721RandomSeed, ERC721PsiBatch
         uint256 quantity,
         bytes memory _data
     ) internal virtual override {
-        uint256 tokenIdHead = _minted;
-        _batchHeadtokenGen[tokenIdHead] = currentGen;
+        uint256 nextTokenId = _nextTokenId();
+        _batchHeadtokenGen[nextTokenId] = currentGen;
         super._safeMint(to, quantity, _data);
     }
 

--- a/contracts/extension/ERC721PsiRandomSeedRevealUpgradeable.sol
+++ b/contracts/extension/ERC721PsiRandomSeedRevealUpgradeable.sol
@@ -66,8 +66,8 @@ abstract contract ERC721PsiRandomSeedRevealUpgradeable is IERC721RandomSeed, ERC
         uint256 quantity,
         bytes memory _data
     ) internal virtual override {
-        uint256 tokenIdHead = _minted;
-        _batchHeadtokenGen[tokenIdHead] = currentGen;
+        uint256 nextTokenId = _nextTokenId();
+        _batchHeadtokenGen[nextTokenId] = currentGen;
         super._safeMint(to, quantity, _data);
     }
 

--- a/contracts/extension/ERC721PsiRandomSeedUpgradeable.sol
+++ b/contracts/extension/ERC721PsiRandomSeedUpgradeable.sol
@@ -60,7 +60,7 @@ abstract contract ERC721PsiRandomSeedUpgradeable is IERC721RandomSeed, ERC721Psi
         uint256 quantity,
         bytes memory _data
     ) internal virtual override {
-        uint256 tokenIdHead = _minted;
+        uint256 nextTokenId = _nextTokenId();
 
         uint256 requestId = COORDINATOR.requestRandomWords(
             _keyHash(),
@@ -71,9 +71,9 @@ abstract contract ERC721PsiRandomSeedUpgradeable is IERC721RandomSeed, ERC721Psi
         );
 
         emit RandomnessRequest(requestId);
-        requestIdToTokenId[requestId] = tokenIdHead;
+        requestIdToTokenId[requestId] = nextTokenId;
         super._safeMint(to, quantity, _data);
-        _processRandomnessRequest(requestId, tokenIdHead);
+        _processRandomnessRequest(requestId, nextTokenId);
     }
 
     /** 

--- a/test/ERC721Psi.js
+++ b/test/ERC721Psi.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const { ZERO_ADDRESS } = constants;
 
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
@@ -75,6 +76,14 @@ describe('ERC721Psi', function () {
 
       it('reverts for an invalid token', async function () {
         await expect(this.ERC721Psi.ownerOf(10)).to.be.revertedWith('ERC721Psi: owner query for nonexistent token');
+      });
+    });
+
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
       });
     });
 
@@ -156,10 +165,6 @@ describe('ERC721Psi', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiAddressData.js
+++ b/test/ERC721PsiAddressData.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const { ZERO_ADDRESS } = constants;
 
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
@@ -75,6 +76,14 @@ describe('ERC721PsiAddressData', function () {
 
       it('reverts for an invalid token', async function () {
         await expect(this.ERC721Psi.ownerOf(10)).to.be.revertedWith('ERC721Psi: owner query for nonexistent token');
+      });
+    });
+
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
       });
     });
 
@@ -156,10 +165,6 @@ describe('ERC721PsiAddressData', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiAddressDataUpgradeable.js
+++ b/test/ERC721PsiAddressDataUpgradeable.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const { ethers, upgrades } = require("hardhat");
 const { ZERO_ADDRESS } = constants;
 
@@ -82,6 +83,14 @@ describe('ERC721PsiAddressDataUpgradeable', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -160,10 +169,6 @@ describe('ERC721PsiAddressDataUpgradeable', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiBurnable.js
+++ b/test/ERC721PsiBurnable.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const { zeroAddress } = require('ethereumjs-blockchain/node_modules/ethereumjs-util');
 const { ZERO_ADDRESS } = constants;
 
@@ -76,6 +77,14 @@ describe('ERC721PsiBurnable', function () {
 
       it('reverts for an invalid token', async function () {
         await expect(this.ERC721Psi.ownerOf(10)).to.be.revertedWith('ERC721Psi: owner query for nonexistent token');
+      });
+    });
+
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
       });
     });
 
@@ -158,10 +167,6 @@ describe('ERC721PsiBurnable', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiBurnableUpgradeable.js
+++ b/test/ERC721PsiBurnableUpgradeable.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const { zeroAddress } = require('ethereumjs-blockchain/node_modules/ethereumjs-util');
 const { ZERO_ADDRESS } = constants;
 
@@ -82,6 +83,14 @@ describe('ERC721PsiBurnableUpgradeable', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -161,10 +170,6 @@ describe('ERC721PsiBurnableUpgradeable', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiRandomSeed.js
+++ b/test/ERC721PsiRandomSeed.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const ether = require('@openzeppelin/test-helpers/src/ether');
 const { ZERO_ADDRESS } = constants;
 
@@ -153,6 +154,14 @@ describe('ERC721PsiRandomSeed', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -231,10 +240,6 @@ describe('ERC721PsiRandomSeed', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiRandomSeedReveal.js
+++ b/test/ERC721PsiRandomSeedReveal.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const ether = require('@openzeppelin/test-helpers/src/ether');
 const { ZERO_ADDRESS } = constants;
 
@@ -144,6 +145,14 @@ describe('ERC721PsiReveal', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -222,10 +231,6 @@ describe('ERC721PsiReveal', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiRandomSeedRevealUpgradeable.js
+++ b/test/ERC721PsiRandomSeedRevealUpgradeable.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const ether = require('@openzeppelin/test-helpers/src/ether');
 const { ZERO_ADDRESS } = constants;
 
@@ -154,6 +155,14 @@ describe('ERC721PsiRandomSeedRevealUpgradeable', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -232,10 +241,6 @@ describe('ERC721PsiRandomSeedRevealUpgradeable', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiRandomSeedUpgradeable.js
+++ b/test/ERC721PsiRandomSeedUpgradeable.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const ether = require('@openzeppelin/test-helpers/src/ether');
 const { ZERO_ADDRESS } = constants;
 
@@ -163,6 +164,14 @@ describe('ERC721PsiRandomSeedUpgradeable', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -241,10 +250,6 @@ describe('ERC721PsiRandomSeedUpgradeable', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {

--- a/test/ERC721PsiUpgradeable.js
+++ b/test/ERC721PsiUpgradeable.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
+const { BigNumber } = require('ethers');
 const { ethers, upgrades } = require("hardhat");
 const { ZERO_ADDRESS } = constants;
 
@@ -82,6 +83,14 @@ describe('ERC721PsiUpgradeable', function () {
       });
     });
 
+    describe('tokensOfOwner', async function () {
+      it('returns the right owner list', async function () {
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr1.address)).to.eqls([new BigNumber.from("0")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr2.address)).to.eqls([new BigNumber.from("1"), new BigNumber.from("2")]);
+        expect(await this.ERC721Psi.tokensOfOwner(this.addr3.address)).to.eqls([new BigNumber.from("3"), new BigNumber.from("4"), new BigNumber.from("5")]);
+      });
+    });
+
     describe('approve', async function () {
       const tokenId = 0;
       const tokenId2 = 1;
@@ -160,10 +169,6 @@ describe('ERC721PsiUpgradeable', function () {
           expect(await this.ERC721Psi.balanceOf(from)).to.be.equal(1);
         });
 
-        it('adjusts owners tokens by index', async function () {
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(to, 0)).to.be.equal(tokenId);
-          expect(await this.ERC721Psi.tokenOfOwnerByIndex(from, 0)).to.be.not.equal(tokenId);
-        });
       };
 
       const testUnsuccessfulTransfer = function (transferFn) {


### PR DESCRIPTION
…RC721A convention

This PR removes the Enumerable extension and introduce the `tokensOfOwner` function from the `IERC721AQueryable`

In addition, `_minted` has be renamed to `_currentIndex` to match ERC721A's naming. Along with that, `_nextTokenId` and `_totalMinted` are also added.

