### PR TITLE
Adds _startTokenId overrideability

### DIFF
--- a/contracts/ERC721Psi.sol
+++ b/contracts/ERC721Psi.sol
@@ -55,8 +55,7 @@ contract ERC721Psi is Context, ERC165, IERC721, IERC721Metadata {
      * @dev Returns the starting token ID.
      * To change the starting token ID, please override this function.
      */
-    function _startTokenId() internal pure returns (uint256) {
-        // It will become modifiable in the future versions
+    function _startTokenId() internal pure virtual returns (uint256) {
         return 0;
     }
 

--- a/contracts/ERC721PsiUpgradeable.sol
+++ b/contracts/ERC721PsiUpgradeable.sol
@@ -58,12 +58,12 @@ contract ERC721PsiUpgradeable is Initializable, ContextUpgradeable,
         _currentIndex = _startTokenId();
     }
 
+
     /**
      * @dev Returns the starting token ID.
      * To change the starting token ID, please override this function.
      */
-    function _startTokenId() internal pure returns (uint256) {
-        // It will become modifiable in the future versions
+    function _startTokenId() internal pure virtual returns (uint256) {
         return 0;
     }
 

--- a/contracts/mock/ERC721PsiMock.sol
+++ b/contracts/mock/ERC721PsiMock.sol
@@ -9,6 +9,9 @@ import "hardhat/console.sol";
 contract ERC721PsiMock is ERC721Psi {
     constructor(string memory name_, string memory symbol_) ERC721Psi(name_, symbol_) {}
 
+    function _startTokenId() internal pure override returns (uint256) {
+        return 0;
+    }
 
     function baseURI() public view returns (string memory) {
         return _baseURI();

--- a/contracts/mock/ERC721PsiMockUpgradeable.sol
+++ b/contracts/mock/ERC721PsiMockUpgradeable.sol
@@ -15,6 +15,9 @@ contract ERC721PsiMockUpgradeable is ERC721PsiUpgradeable {
         __ERC721Psi_init(name_, symbol_);
     }
 
+    function _startTokenId() internal pure override returns (uint256) {
+        return 0;
+    }
 
     function baseURI() public view returns (string memory) {
         return _baseURI();


### PR DESCRIPTION
Makes _startTokenId overrideable with overrided methods added to the mocks for code coverage for gh issue #7 